### PR TITLE
Implement Sprint 2 active session core

### DIFF
--- a/Config/InterviewPartner-Info.plist
+++ b/Config/InterviewPartner-Info.plist
@@ -24,6 +24,8 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Interview Partner needs microphone access to transcribe live interviews on device.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Interview Partner uses speech recognition as a local fallback if the primary on-device transcription engine is unavailable.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/InterviewPartner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InterviewPartner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,113 @@
+{
+  "originHash" : "b2071e7154d07bb0c679d4c91865ae51b1a764f755a3db0a534eb1db8cfc8b5d",
+  "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "fluidaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidInference/FluidAudio.git",
+      "state" : {
+        "revision" : "9830ce835881c0d0d40f90aabfaae3a6da5bebfb"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
+        "version" : "4.3.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "f731f03bf746481d4fda07f817c3774390c4d5b9",
+        "version" : "2.3.2"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "b31565862a8f39866af50bc6676160d8dda7de35",
+        "version" : "2.96.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "eed7264ac5e4ec5dfa6165c6e5c5577364344fe4",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/InterviewPartner/InterviewPartnerApp.swift
+++ b/InterviewPartner/InterviewPartnerApp.swift
@@ -5,13 +5,13 @@ import InterviewPartnerServices
 
 @main
 struct InterviewPartnerApp: App {
-    private let appEnvironment: Sprint1AppEnvironment
+    private let appEnvironment: AppEnvironment
 
     init() {
         do {
-            appEnvironment = try Sprint1AppEnvironment()
+            appEnvironment = try AppEnvironment()
         } catch {
-            fatalError("Failed to bootstrap Sprint 1 environment: \(error)")
+            fatalError("Failed to bootstrap app environment: \(error)")
         }
     }
 

--- a/Packages/InterviewPartnerData/Sources/InterviewPartnerData/PersistenceModels.swift
+++ b/Packages/InterviewPartnerData/Sources/InterviewPartnerData/PersistenceModels.swift
@@ -108,6 +108,10 @@ public final class TranscriptTurn {
     public var text: String
     public var timestamp: Date
     public var isFinal: Bool
+    public var startTimeSeconds: Double?
+    public var endTimeSeconds: Double?
+    public var speakerMatchConfidence: Double?
+    public var speakerLabelIsProvisional: Bool
     public var session: Session?
 
     public init(
@@ -116,6 +120,10 @@ public final class TranscriptTurn {
         text: String,
         timestamp: Date = .now,
         isFinal: Bool = true,
+        startTimeSeconds: Double? = nil,
+        endTimeSeconds: Double? = nil,
+        speakerMatchConfidence: Double? = nil,
+        speakerLabelIsProvisional: Bool = false,
         session: Session? = nil
     ) {
         self.id = id
@@ -123,6 +131,10 @@ public final class TranscriptTurn {
         self.text = text
         self.timestamp = timestamp
         self.isFinal = isFinal
+        self.startTimeSeconds = startTimeSeconds
+        self.endTimeSeconds = endTimeSeconds
+        self.speakerMatchConfidence = speakerMatchConfidence
+        self.speakerLabelIsProvisional = speakerLabelIsProvisional
         self.session = session
     }
 }

--- a/Packages/InterviewPartnerData/Sources/InterviewPartnerData/SwiftDataSessionRepository.swift
+++ b/Packages/InterviewPartnerData/Sources/InterviewPartnerData/SwiftDataSessionRepository.swift
@@ -38,17 +38,202 @@ public final class SwiftDataSessionRepository: SessionRepository {
         }
     }
 
+    public func fetchSession(id: UUID) throws -> SessionRecord? {
+        try fetchSessionModel(id: id).map(Self.record(from:))
+    }
+
     @discardableResult
     public func createSession(
         guideSnapshot: GuideSnapshot,
         participantLabel: String?
-    ) throws -> UUID {
+    ) throws -> SessionRecord {
+        let questionStatuses = guideSnapshot.questions.map { question in
+            QuestionStatus(
+                questionID: question.id,
+                status: .notStarted
+            )
+        }
         let session = Session(
             guideSnapshot: guideSnapshot,
-            participantLabel: participantLabel
+            participantLabel: participantLabel,
+            questionStatuses: questionStatuses
         )
         modelContainer.mainContext.insert(session)
         try modelContainer.mainContext.save()
-        return session.id
+        return Self.record(from: session)
+    }
+
+    public func appendTranscriptTurn(_ turn: InterviewPartnerDomain.TranscriptTurn, to sessionID: UUID) throws {
+        let session = try requireSession(id: sessionID)
+        let turnModel = TranscriptTurn(
+            id: turn.id,
+            speakerLabel: turn.speakerLabel,
+            text: turn.text,
+            timestamp: turn.timestamp,
+            isFinal: turn.isFinal,
+            startTimeSeconds: turn.startTimeSeconds,
+            endTimeSeconds: turn.endTimeSeconds,
+            speakerMatchConfidence: turn.speakerMatchConfidence,
+            speakerLabelIsProvisional: turn.speakerLabelIsProvisional,
+            session: session
+        )
+        modelContainer.mainContext.insert(turnModel)
+        session.transcriptTurns.append(turnModel)
+        try modelContainer.mainContext.save()
+    }
+
+    public func appendTranscriptGap(_ gap: InterviewPartnerDomain.TranscriptGap, to sessionID: UUID) throws {
+        let session = try requireSession(id: sessionID)
+        let gapModel = TranscriptGap(
+            id: gap.id,
+            sessionID: gap.sessionID,
+            startTimestamp: gap.startTimestamp,
+            endTimestamp: gap.endTimestamp,
+            reason: gap.reason,
+            session: session
+        )
+        modelContainer.mainContext.insert(gapModel)
+        session.transcriptGaps.append(gapModel)
+        try modelContainer.mainContext.save()
+    }
+
+    public func upsertQuestionStatus(_ status: QuestionAnswerStatus, for sessionID: UUID) throws {
+        let session = try requireSession(id: sessionID)
+
+        if let existing = session.questionStatuses.first(where: { $0.questionID == status.questionID }) {
+            existing.status = status.status
+            existing.aiScore = status.aiScore
+        } else {
+            let newStatus = QuestionStatus(
+                id: status.id,
+                questionID: status.questionID,
+                status: status.status,
+                aiScore: status.aiScore,
+                session: session
+            )
+            modelContainer.mainContext.insert(newStatus)
+            session.questionStatuses.append(newStatus)
+        }
+
+        try modelContainer.mainContext.save()
+    }
+
+    public func appendAdHocNote(_ note: InterviewPartnerDomain.AdHocNote, to sessionID: UUID) throws {
+        let session = try requireSession(id: sessionID)
+        let noteModel = AdHocNote(
+            id: note.id,
+            text: note.text,
+            timestamp: note.timestamp,
+            session: session
+        )
+        modelContainer.mainContext.insert(noteModel)
+        session.adHocNotes.append(noteModel)
+        try modelContainer.mainContext.save()
+    }
+
+    public func finalizeSession(
+        id: UUID,
+        endedAt: Date,
+        reconciledTurns: [InterviewPartnerDomain.TranscriptTurn]
+    ) throws -> SessionRecord {
+        let session = try requireSession(id: id)
+        session.endedAt = endedAt
+
+        let turnsByID = Dictionary(uniqueKeysWithValues: session.transcriptTurns.map { ($0.id, $0) })
+        for turn in reconciledTurns {
+            guard let existing = turnsByID[turn.id] else { continue }
+            existing.speakerLabel = turn.speakerLabel
+            existing.text = turn.text
+            existing.timestamp = turn.timestamp
+            existing.isFinal = turn.isFinal
+            existing.startTimeSeconds = turn.startTimeSeconds
+            existing.endTimeSeconds = turn.endTimeSeconds
+            existing.speakerMatchConfidence = turn.speakerMatchConfidence
+            existing.speakerLabelIsProvisional = turn.speakerLabelIsProvisional
+        }
+
+        try modelContainer.mainContext.save()
+        return Self.record(from: session)
+    }
+
+    private func fetchSessionModel(id: UUID) throws -> Session? {
+        var descriptor = FetchDescriptor<Session>(
+            predicate: #Predicate<Session> { session in
+                session.id == id
+            }
+        )
+        descriptor.fetchLimit = 1
+        return try modelContainer.mainContext.fetch(descriptor).first
+    }
+
+    private func requireSession(id: UUID) throws -> Session {
+        guard let session = try fetchSessionModel(id: id) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return session
+    }
+
+    private static func record(from session: Session) -> SessionRecord {
+        SessionRecord(
+            id: session.id,
+            guideSnapshot: session.guideSnapshot,
+            participantLabel: session.participantLabel,
+            startedAt: session.startedAt,
+            endedAt: session.endedAt,
+            transcriptTurns: session.transcriptTurns
+                .sorted { $0.timestamp < $1.timestamp }
+                .map(Self.domainTurn(from:)),
+            transcriptGaps: session.transcriptGaps
+                .sorted { $0.startTimestamp < $1.startTimestamp }
+                .map(Self.domainGap(from:)),
+            questionStatuses: session.questionStatuses
+                .map(Self.domainStatus(from:))
+                .sorted { $0.questionID.uuidString < $1.questionID.uuidString },
+            adHocNotes: session.adHocNotes
+                .sorted { $0.timestamp < $1.timestamp }
+                .map(Self.domainNote(from:)),
+            hasPendingExport: !session.exportQueueEntries.isEmpty
+        )
+    }
+
+    private static func domainTurn(from turn: TranscriptTurn) -> InterviewPartnerDomain.TranscriptTurn {
+        InterviewPartnerDomain.TranscriptTurn(
+            id: turn.id,
+            speakerLabel: turn.speakerLabel,
+            text: turn.text,
+            timestamp: turn.timestamp,
+            isFinal: turn.isFinal,
+            startTimeSeconds: turn.startTimeSeconds,
+            endTimeSeconds: turn.endTimeSeconds,
+            speakerMatchConfidence: turn.speakerMatchConfidence,
+            speakerLabelIsProvisional: turn.speakerLabelIsProvisional
+        )
+    }
+
+    private static func domainGap(from gap: TranscriptGap) -> InterviewPartnerDomain.TranscriptGap {
+        InterviewPartnerDomain.TranscriptGap(
+            id: gap.id,
+            sessionID: gap.sessionID,
+            startTimestamp: gap.startTimestamp,
+            endTimestamp: gap.endTimestamp,
+            reason: gap.reason
+        )
+    }
+
+    private static func domainStatus(from status: QuestionStatus) -> QuestionAnswerStatus {
+        QuestionAnswerStatus(
+            id: status.id,
+            questionID: status.questionID,
+            status: status.status,
+            aiScore: status.aiScore
+        )
+    }
+
+    private static func domainNote(from note: AdHocNote) -> InterviewPartnerDomain.AdHocNote {
+        InterviewPartnerDomain.AdHocNote(
+            id: note.id,
+            text: note.text,
+            timestamp: note.timestamp
+        )
     }
 }

--- a/Packages/InterviewPartnerData/Tests/InterviewPartnerDataTests/SessionRepositoryTests.swift
+++ b/Packages/InterviewPartnerData/Tests/InterviewPartnerDataTests/SessionRepositoryTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+import InterviewPartnerDomain
+@testable import InterviewPartnerData
+
+@MainActor
+@Test func createSessionSeedsQuestionStatusesAndSummary() throws {
+    let container = try InterviewPartnerModelContainer.make(inMemoryOnly: true)
+    let repository = SwiftDataSessionRepository(modelContainer: container)
+
+    let record = try repository.createSession(
+        guideSnapshot: GuideSnapshot(
+            id: UUID(),
+            name: "Discovery",
+            goal: "Understand the workflow.",
+            createdAt: .now,
+            questions: [
+                GuideSnapshotQuestion(
+                    id: UUID(),
+                    text: "Walk me through your last interview.",
+                    priority: .mustCover,
+                    orderIndex: 0,
+                    subPrompts: []
+                ),
+                GuideSnapshotQuestion(
+                    id: UUID(),
+                    text: "What slowed you down?",
+                    priority: .shouldCover,
+                    orderIndex: 1,
+                    subPrompts: []
+                ),
+            ]
+        ),
+        participantLabel: "Taylor"
+    )
+
+    let summaries = try repository.fetchSessions()
+
+    #expect(record.participantLabel == "Taylor")
+    #expect(record.questionStatuses.count == 2)
+    #expect(record.questionStatuses.allSatisfy { $0.status == .notStarted })
+    #expect(summaries.count == 1)
+    #expect(summaries.first?.mustCoverQuestionCount == 1)
+}
+
+@MainActor
+@Test func sessionRepositoryPersistsIncrementalSessionUpdates() throws {
+    let container = try InterviewPartnerModelContainer.make(inMemoryOnly: true)
+    let repository = SwiftDataSessionRepository(modelContainer: container)
+    let questionID = UUID()
+
+    let created = try repository.createSession(
+        guideSnapshot: GuideSnapshot(
+            id: UUID(),
+            name: "Behavioral",
+            goal: "Assess depth.",
+            createdAt: .now,
+            questions: [
+                GuideSnapshotQuestion(
+                    id: questionID,
+                    text: "Tell me about a launch.",
+                    priority: .mustCover,
+                    orderIndex: 0,
+                    subPrompts: []
+                ),
+            ]
+        ),
+        participantLabel: nil
+    )
+
+    let turn = TranscriptTurn(
+        speakerLabel: "Speaker A",
+        text: "We launched in phases.",
+        timestamp: .now,
+        isFinal: true,
+        startTimeSeconds: 0,
+        endTimeSeconds: 4,
+        speakerMatchConfidence: 0.82,
+        speakerLabelIsProvisional: true
+    )
+    try repository.appendTranscriptTurn(turn, to: created.id)
+
+    let gap = TranscriptGap(
+        sessionID: created.id,
+        startTimestamp: .now,
+        endTimestamp: .now.addingTimeInterval(12),
+        reason: .transcriptionUnavailable
+    )
+    try repository.appendTranscriptGap(gap, to: created.id)
+
+    let status = QuestionAnswerStatus(questionID: questionID, status: .answered)
+    try repository.upsertQuestionStatus(status, for: created.id)
+
+    let note = AdHocNote(text: "Probe onboarding path.", timestamp: .now)
+    try repository.appendAdHocNote(note, to: created.id)
+
+    let finalized = try repository.finalizeSession(
+        id: created.id,
+        endedAt: .now.addingTimeInterval(300),
+        reconciledTurns: [
+            TranscriptTurn(
+                id: turn.id,
+                speakerLabel: "Speaker B",
+                text: turn.text,
+                timestamp: turn.timestamp,
+                isFinal: true,
+                startTimeSeconds: turn.startTimeSeconds,
+                endTimeSeconds: turn.endTimeSeconds,
+                speakerMatchConfidence: 0.91,
+                speakerLabelIsProvisional: false
+            ),
+        ]
+    )
+
+    #expect(finalized.transcriptTurns.count == 1)
+    #expect(finalized.transcriptTurns.first?.speakerLabel == "Speaker B")
+    #expect(finalized.transcriptTurns.first?.speakerLabelIsProvisional == false)
+    #expect(finalized.transcriptGaps.count == 1)
+    #expect(finalized.adHocNotes.count == 1)
+    #expect(finalized.questionStatuses.first?.status == .answered)
+    #expect(finalized.endedAt != nil)
+}

--- a/Packages/InterviewPartnerDomain/Sources/InterviewPartnerDomain/GuideModels.swift
+++ b/Packages/InterviewPartnerDomain/Sources/InterviewPartnerDomain/GuideModels.swift
@@ -269,6 +269,27 @@ public struct GuideExportDocument: Codable, Hashable, Sendable, Identifiable {
         case branch
         case aiScoringPromptOverride = "ai_scoring_prompt_override"
     }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(goal, forKey: .goal)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(questions, forKey: .questions)
+
+        if let branch {
+            try container.encode(branch, forKey: .branch)
+        } else {
+            try container.encodeNil(forKey: .branch)
+        }
+
+        if let aiScoringPromptOverride {
+            try container.encode(aiScoringPromptOverride, forKey: .aiScoringPromptOverride)
+        } else {
+            try container.encodeNil(forKey: .aiScoringPromptOverride)
+        }
+    }
 }
 
 public struct WorkspaceStatus: Equatable, Sendable {

--- a/Packages/InterviewPartnerDomain/Sources/InterviewPartnerDomain/RepositoryProtocols.swift
+++ b/Packages/InterviewPartnerDomain/Sources/InterviewPartnerDomain/RepositoryProtocols.swift
@@ -14,11 +14,21 @@ public protocol GuideRepository: AnyObject {
 @MainActor
 public protocol SessionRepository: AnyObject {
     func fetchSessions() throws -> [SessionSummary]
+    func fetchSession(id: UUID) throws -> SessionRecord?
     @discardableResult
     func createSession(
         guideSnapshot: GuideSnapshot,
         participantLabel: String?
-    ) throws -> UUID
+    ) throws -> SessionRecord
+    func appendTranscriptTurn(_ turn: TranscriptTurn, to sessionID: UUID) throws
+    func appendTranscriptGap(_ gap: TranscriptGap, to sessionID: UUID) throws
+    func upsertQuestionStatus(_ status: QuestionAnswerStatus, for sessionID: UUID) throws
+    func appendAdHocNote(_ note: AdHocNote, to sessionID: UUID) throws
+    func finalizeSession(
+        id: UUID,
+        endedAt: Date,
+        reconciledTurns: [TranscriptTurn]
+    ) throws -> SessionRecord
 }
 
 @MainActor
@@ -40,6 +50,7 @@ public protocol WorkspaceGuideImporter: AnyObject {
 @MainActor
 public protocol PermissionManager: AnyObject {
     func microphonePermissionState() -> MicrophonePermissionState
+    func requestMicrophonePermission() async -> MicrophonePermissionState
 }
 
 @MainActor

--- a/Packages/InterviewPartnerDomain/Sources/InterviewPartnerDomain/SessionModels.swift
+++ b/Packages/InterviewPartnerDomain/Sources/InterviewPartnerDomain/SessionModels.swift
@@ -34,19 +34,31 @@ public struct TranscriptTurn: Identifiable, Codable, Hashable, Sendable {
     public var text: String
     public var timestamp: Date
     public var isFinal: Bool
+    public var startTimeSeconds: TimeInterval?
+    public var endTimeSeconds: TimeInterval?
+    public var speakerMatchConfidence: Double?
+    public var speakerLabelIsProvisional: Bool
 
     public init(
         id: UUID = UUID(),
         speakerLabel: String = "Speaker A",
         text: String,
         timestamp: Date = .now,
-        isFinal: Bool = true
+        isFinal: Bool = true,
+        startTimeSeconds: TimeInterval? = nil,
+        endTimeSeconds: TimeInterval? = nil,
+        speakerMatchConfidence: Double? = nil,
+        speakerLabelIsProvisional: Bool = false
     ) {
         self.id = id
         self.speakerLabel = speakerLabel
         self.text = text
         self.timestamp = timestamp
         self.isFinal = isFinal
+        self.startTimeSeconds = startTimeSeconds
+        self.endTimeSeconds = endTimeSeconds
+        self.speakerMatchConfidence = speakerMatchConfidence
+        self.speakerLabelIsProvisional = speakerLabelIsProvisional
     }
 }
 
@@ -134,6 +146,43 @@ public struct SessionSummary: Identifiable, Hashable, Sendable {
         self.endedAt = endedAt
         self.mustCoverQuestionCount = mustCoverQuestionCount
         self.answeredMustCoverCount = answeredMustCoverCount
+        self.hasPendingExport = hasPendingExport
+    }
+}
+
+public struct SessionRecord: Identifiable, Codable, Hashable, Sendable {
+    public var id: UUID
+    public var guideSnapshot: GuideSnapshot
+    public var participantLabel: String?
+    public var startedAt: Date
+    public var endedAt: Date?
+    public var transcriptTurns: [TranscriptTurn]
+    public var transcriptGaps: [TranscriptGap]
+    public var questionStatuses: [QuestionAnswerStatus]
+    public var adHocNotes: [AdHocNote]
+    public var hasPendingExport: Bool
+
+    public init(
+        id: UUID,
+        guideSnapshot: GuideSnapshot,
+        participantLabel: String?,
+        startedAt: Date,
+        endedAt: Date?,
+        transcriptTurns: [TranscriptTurn],
+        transcriptGaps: [TranscriptGap],
+        questionStatuses: [QuestionAnswerStatus],
+        adHocNotes: [AdHocNote],
+        hasPendingExport: Bool
+    ) {
+        self.id = id
+        self.guideSnapshot = guideSnapshot
+        self.participantLabel = participantLabel
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.transcriptTurns = transcriptTurns
+        self.transcriptGaps = transcriptGaps
+        self.questionStatuses = questionStatuses
+        self.adHocNotes = adHocNotes
         self.hasPendingExport = hasPendingExport
     }
 }

--- a/Packages/InterviewPartnerFeatures/Sources/InterviewPartnerFeatures/ActiveSessionFeature.swift
+++ b/Packages/InterviewPartnerFeatures/Sources/InterviewPartnerFeatures/ActiveSessionFeature.swift
@@ -1,0 +1,956 @@
+import Combine
+import Observation
+import SwiftUI
+import InterviewPartnerDomain
+import InterviewPartnerServices
+
+@MainActor
+@Observable
+final class SessionCoordinator: Identifiable {
+    let id: UUID
+
+    @ObservationIgnored
+    private let sessionRepository: any SessionRepository
+    @ObservationIgnored
+    private let transcriptionService: any TranscriptionService
+
+    private var timerCancellable: AnyCancellable?
+    private var didStart = false
+    private var skipUndoResetTask: Task<Void, Never>?
+
+    var guideSnapshot: GuideSnapshot
+    var participantLabel: String?
+    var startedAt: Date
+    var endedAt: Date?
+    var transcript: [TranscriptTurn]
+    var gaps: [TranscriptGap]
+    var partialTurn: String?
+    var questionStatuses: [QuestionAnswerStatus]
+    var adHocNotes: [AdHocNote]
+    var elapsedSeconds: Int
+    var diarizationAvailable = true
+    var limitedModeMessage: String?
+    var diarizationSnapshot: DiarizationSnapshot?
+    var errorMessage: String?
+    var isEnding = false
+    var didFinishSession = false
+    var skipUndoState: SkipUndoState?
+
+    init(
+        session: SessionRecord,
+        sessionRepository: any SessionRepository,
+        transcriptionService: any TranscriptionService
+    ) {
+        id = session.id
+        self.sessionRepository = sessionRepository
+        self.transcriptionService = transcriptionService
+        guideSnapshot = session.guideSnapshot
+        participantLabel = session.participantLabel
+        startedAt = session.startedAt
+        endedAt = session.endedAt
+        transcript = session.transcriptTurns
+        gaps = session.transcriptGaps
+        partialTurn = nil
+        questionStatuses = session.questionStatuses
+        adHocNotes = session.adHocNotes
+        elapsedSeconds = max(Int(Date.now.timeIntervalSince(session.startedAt)), 0)
+    }
+
+    func startIfNeeded() async {
+        guard !didStart else { return }
+        didStart = true
+
+        transcriptionService.setEventHandler { [weak self] event in
+            Task { @MainActor [weak self] in
+                self?.handleTranscriptionEvent(event)
+            }
+        }
+
+        startTimer()
+
+        do {
+            try await transcriptionService.start(sessionID: id, startedAt: startedAt)
+        } catch {
+            timerCancellable?.cancel()
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func handleScenePhase(_ phase: ScenePhase) {
+        switch phase {
+        case .active:
+            startTimer()
+        case .background, .inactive:
+            timerCancellable?.cancel()
+        @unknown default:
+            break
+        }
+    }
+
+    func endSession() async {
+        guard !isEnding else { return }
+        isEnding = true
+        timerCancellable?.cancel()
+
+        let stopResult = await transcriptionService.stop()
+        transcript = stopResult.reconciledTurns.sorted { $0.timestamp < $1.timestamp }
+        diarizationSnapshot = stopResult.diarizationSnapshot
+        diarizationAvailable = stopResult.diarizationAvailable
+        limitedModeMessage = stopResult.limitedModeMessage
+        partialTurn = nil
+        endedAt = .now
+
+        do {
+            let record = try sessionRepository.finalizeSession(
+                id: id,
+                endedAt: endedAt ?? .now,
+                reconciledTurns: transcript
+            )
+            transcript = record.transcriptTurns
+            gaps = record.transcriptGaps
+            questionStatuses = record.questionStatuses
+            adHocNotes = record.adHocNotes
+            endedAt = record.endedAt
+            didFinishSession = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isEnding = false
+    }
+
+    func cycleStatus(for questionID: UUID) {
+        updateQuestionStatus(questionID: questionID, status: currentStatus(for: questionID).nextTapStatus)
+    }
+
+    func skipQuestion(_ questionID: UUID) {
+        let previousStatus = currentStatus(for: questionID)
+        updateQuestionStatus(questionID: questionID, status: .skipped)
+        skipUndoState = SkipUndoState(questionID: questionID, previousStatus: previousStatus)
+        scheduleSkipUndoReset()
+    }
+
+    func undoLastSkip() {
+        guard let skipUndoState else { return }
+        skipUndoResetTask?.cancel()
+        updateQuestionStatus(
+            questionID: skipUndoState.questionID,
+            status: skipUndoState.previousStatus
+        )
+        self.skipUndoState = nil
+    }
+
+    func addAdHocNote(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let note = AdHocNote(text: trimmed, timestamp: .now)
+        adHocNotes.append(note)
+
+        do {
+            try sessionRepository.appendAdHocNote(note, to: id)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func status(for questionID: UUID) -> QuestionCoverageStatus {
+        currentStatus(for: questionID)
+    }
+
+    func questions(for priority: QuestionPriority) -> [GuideSnapshotQuestion] {
+        guideSnapshot.questions
+            .filter { $0.priority == priority }
+            .sorted { lhs, rhs in
+                let lhsStatus = currentStatus(for: lhs.id)
+                let rhsStatus = currentStatus(for: rhs.id)
+
+                if lhsStatus.displayRank == rhsStatus.displayRank {
+                    return lhs.orderIndex < rhs.orderIndex
+                }
+
+                return lhsStatus.displayRank < rhsStatus.displayRank
+            }
+    }
+
+    var headerTitle: String {
+        participantLabel ?? guideSnapshot.name
+    }
+
+    var mustCoverProgressText: String {
+        let mustCoverQuestions = guideSnapshot.questions.filter { $0.priority == .mustCover }
+        let answered = mustCoverQuestions.filter { currentStatus(for: $0.id) == .answered }.count
+        let elapsedMinutes = elapsedSeconds / 60
+        return "\(answered) of \(mustCoverQuestions.count) Must Cover · \(elapsedMinutes)m elapsed"
+    }
+
+    var canShowLimitedModeBanner: Bool {
+        limitedModeMessage != nil
+    }
+
+    private func startTimer() {
+        timerCancellable?.cancel()
+        timerCancellable = Timer.publish(every: 1, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self else { return }
+                elapsedSeconds = max(Int(Date.now.timeIntervalSince(startedAt)), 0)
+            }
+    }
+
+    private func handleTranscriptionEvent(_ event: TranscriptionServiceEvent) {
+        switch event {
+        case .partialText(let text):
+            partialTurn = text.isEmpty ? nil : text
+
+        case .finalizedTurn(let turn):
+            transcript.append(turn)
+            do {
+                try sessionRepository.appendTranscriptTurn(turn, to: id)
+                errorMessage = nil
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+
+        case .transcriptGap(let gap):
+            gaps.append(gap)
+            do {
+                try sessionRepository.appendTranscriptGap(gap, to: id)
+                errorMessage = nil
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+
+        case .diarizationSnapshot(let snapshot):
+            diarizationSnapshot = snapshot
+
+        case .limitedModeChanged(let isLimited, let message):
+            diarizationAvailable = !isLimited
+            limitedModeMessage = message
+        }
+    }
+
+    private func currentStatus(for questionID: UUID) -> QuestionCoverageStatus {
+        questionStatuses.first(where: { $0.questionID == questionID })?.status ?? .notStarted
+    }
+
+    private func updateQuestionStatus(questionID: UUID, status: QuestionCoverageStatus) {
+        let newStatus = QuestionAnswerStatus(
+            id: questionStatuses.first(where: { $0.questionID == questionID })?.id ?? UUID(),
+            questionID: questionID,
+            status: status,
+            aiScore: nil
+        )
+
+        if let index = questionStatuses.firstIndex(where: { $0.questionID == questionID }) {
+            questionStatuses[index] = newStatus
+        } else {
+            questionStatuses.append(newStatus)
+        }
+
+        do {
+            try sessionRepository.upsertQuestionStatus(newStatus, for: id)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func scheduleSkipUndoReset() {
+        skipUndoResetTask?.cancel()
+        let currentToken = skipUndoState?.id
+        skipUndoResetTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(3))
+            guard let self, skipUndoState?.id == currentToken else { return }
+            skipUndoState = nil
+        }
+    }
+}
+
+struct SkipUndoState: Identifiable, Equatable {
+    let id = UUID()
+    let questionID: UUID
+    let previousStatus: QuestionCoverageStatus
+}
+
+struct ActiveSessionView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var coordinator: SessionCoordinator
+    @State private var panelState: ScriptPanelSnapState = .default
+    @State private var showEndConfirmation = false
+    @State private var showPanicSheet = false
+    @State private var showNoteComposer = false
+    @State private var noteDraft = ""
+
+    init(coordinator: SessionCoordinator) {
+        _coordinator = State(initialValue: coordinator)
+    }
+
+    public var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                SessionHeaderView(
+                    title: coordinator.headerTitle,
+                    elapsedSeconds: coordinator.elapsedSeconds,
+                    onPanicTap: { showPanicSheet = true },
+                    onEndTap: { showEndConfirmation = true }
+                )
+
+                if let limitedModeMessage = coordinator.limitedModeMessage {
+                    LimitedModeBanner(message: limitedModeMessage)
+                        .padding(.horizontal)
+                        .padding(.bottom, 8)
+                }
+
+                TranscriptView(
+                    transcript: coordinator.transcript,
+                    gaps: coordinator.gaps,
+                    partialTurn: coordinator.partialTurn
+                )
+            }
+            .safeAreaInset(edge: .bottom) {
+                ScriptPanelView(
+                    coordinator: coordinator,
+                    panelState: $panelState,
+                    showNoteComposer: $showNoteComposer,
+                    onPanicTap: { showPanicSheet = true }
+                )
+                .frame(height: panelState.height(in: geometry.size.height))
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                .overlay(alignment: .top) {
+                    Capsule()
+                        .fill(Color.secondary.opacity(0.45))
+                        .frame(width: 48, height: 5)
+                        .padding(.top, 8)
+                }
+                .padding(.horizontal, 8)
+                .padding(.bottom, 8)
+                .animation(.spring(response: 0.28, dampingFraction: 0.88), value: panelState)
+                .gesture(
+                    DragGesture(minimumDistance: 12)
+                        .onEnded { value in
+                            panelState = panelState.nextState(for: value.translation.height)
+                        }
+                )
+            }
+            .overlay(alignment: .bottom) {
+                if let skipUndoState = coordinator.skipUndoState {
+                    UndoToast(
+                        text: "Marked skipped",
+                        onUndo: { coordinator.undoLastSkip() }
+                    )
+                    .padding(.bottom, panelState.height(in: geometry.size.height) + 24)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .id(skipUndoState.id)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if showNoteComposer {
+                    QuickNoteOverlay(
+                        noteDraft: $noteDraft,
+                        onCancel: {
+                            noteDraft = ""
+                            showNoteComposer = false
+                        },
+                        onSave: {
+                            coordinator.addAdHocNote(noteDraft)
+                            noteDraft = ""
+                            showNoteComposer = false
+                        }
+                    )
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, panelState.height(in: geometry.size.height) + 24)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+            .sheet(isPresented: $showPanicSheet) {
+                PanicQuestionListView(coordinator: coordinator)
+            }
+            .confirmationDialog(
+                "End interview session?",
+                isPresented: $showEndConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("End Session", role: .destructive) {
+                    Task { await coordinator.endSession() }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This stops live transcription and finalizes the session in history.")
+            }
+            .alert(
+                "Session Error",
+                isPresented: Binding(
+                    get: { coordinator.errorMessage != nil },
+                    set: { isPresented in
+                        if !isPresented {
+                            coordinator.errorMessage = nil
+                        }
+                    }
+                )
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(coordinator.errorMessage ?? "Unknown error")
+            }
+            .task {
+                await coordinator.startIfNeeded()
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                coordinator.handleScenePhase(newPhase)
+            }
+            .onChange(of: coordinator.didFinishSession) { _, didFinish in
+                if didFinish {
+                    dismiss()
+                }
+            }
+            .overlay {
+                if coordinator.isEnding {
+                    ZStack {
+                        Color.black.opacity(0.18).ignoresSafeArea()
+                        ProgressView("Finalizing session...")
+                            .padding(20)
+                            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct SessionHeaderView: View {
+    let title: String
+    let elapsedSeconds: Int
+    let onPanicTap: () -> Void
+    let onEndTap: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                    .lineLimit(1)
+                Text(Self.elapsedString(from: elapsedSeconds))
+                    .font(.footnote.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button(action: onPanicTap) {
+                Image(systemName: "rectangle.grid.1x2")
+                    .font(.headline)
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Show full question list")
+
+            Button("End", role: .destructive, action: onEndTap)
+                .buttonStyle(.borderedProminent)
+        }
+        .padding(.horizontal)
+        .padding(.top, 12)
+        .padding(.bottom, 10)
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    private static func elapsedString(from totalSeconds: Int) -> String {
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        if hours > 0 {
+            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+}
+
+private struct TranscriptView: View {
+    let transcript: [TranscriptTurn]
+    let gaps: [TranscriptGap]
+    let partialTurn: String?
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach(transcriptItems) { item in
+                        switch item {
+                        case .turn(let turn):
+                            TranscriptTurnRow(turn: turn)
+                                .id(turn.id)
+                        case .gap(let gap):
+                            TranscriptGapRow(gap: gap)
+                                .id(gap.id)
+                        }
+                    }
+
+                    if let partialTurn, !partialTurn.isEmpty {
+                        PartialTurnRow(text: partialTurn)
+                            .id("partial-turn")
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 20)
+            }
+            .background(Color(uiColor: .secondarySystemBackground))
+            .onChange(of: transcript.count) { _, _ in
+                if let lastID = transcript.last?.id {
+                    withAnimation(.easeOut(duration: 0.18)) {
+                        proxy.scrollTo(lastID, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private var transcriptItems: [TranscriptItem] {
+        let turnItems = transcript.map(TranscriptItem.turn)
+        let gapItems = gaps.map(TranscriptItem.gap)
+        return (turnItems + gapItems).sorted { lhs, rhs in
+            lhs.sortDate < rhs.sortDate
+        }
+    }
+}
+
+private enum TranscriptItem: Identifiable {
+    case turn(TranscriptTurn)
+    case gap(TranscriptGap)
+
+    var id: AnyHashable {
+        switch self {
+        case .turn(let turn):
+            return turn.id
+        case .gap(let gap):
+            return gap.id
+        }
+    }
+
+    var sortDate: Date {
+        switch self {
+        case .turn(let turn):
+            return turn.timestamp
+        case .gap(let gap):
+            return gap.startTimestamp
+        }
+    }
+}
+
+private struct TranscriptTurnRow: View {
+    let turn: TranscriptTurn
+
+    var body: some View {
+        HStack {
+            if turn.speakerLabel == "Speaker B" {
+                Spacer(minLength: 44)
+            }
+
+            VStack(alignment: turn.speakerLabel == "Speaker B" ? .trailing : .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Text(turn.speakerLabel)
+                        .font(.caption.weight(.semibold))
+                    Text(turn.timestamp.formatted(date: .omitted, time: .standard))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(turn.text)
+                    .foregroundStyle(.primary)
+
+                if turn.speakerLabelIsProvisional {
+                    Text(provisionalSummary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: 320, alignment: turn.speakerLabel == "Speaker B" ? .trailing : .leading)
+            .background(bubbleColor, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+            if turn.speakerLabel != "Speaker B" {
+                Spacer(minLength: 44)
+            }
+        }
+    }
+
+    private var provisionalSummary: String {
+        if let speakerMatchConfidence = turn.speakerMatchConfidence {
+            return "Live label · \(Int((speakerMatchConfidence * 100).rounded()))% confidence"
+        }
+        return "Live label"
+    }
+
+    private var bubbleColor: Color {
+        switch turn.speakerLabel {
+        case "Speaker A":
+            return Color.teal.opacity(0.18)
+        case "Speaker B":
+            return Color.orange.opacity(0.18)
+        default:
+            return Color.secondary.opacity(0.16)
+        }
+    }
+}
+
+private struct TranscriptGapRow: View {
+    let gap: TranscriptGap
+
+    var body: some View {
+        Text("[transcription unavailable \(Self.timeString(gap.startTimestamp))-\(Self.timeString(gap.endTimestamp))]")
+            .font(.caption.monospacedDigit())
+            .foregroundStyle(.secondary)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity)
+    }
+
+    private static func timeString(_ date: Date) -> String {
+        date.formatted(date: .omitted, time: .shortened)
+    }
+}
+
+private struct PartialTurnRow: View {
+    let text: String
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Listening...")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(text)
+            }
+            .padding(12)
+            .background(Color.secondary.opacity(0.12), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            Spacer(minLength: 44)
+        }
+    }
+}
+
+private enum ScriptPanelSnapState: CaseIterable {
+    case collapsed
+    case `default`
+    case expanded
+
+    func height(in availableHeight: CGFloat) -> CGFloat {
+        switch self {
+        case .collapsed:
+            return min(max(availableHeight * 0.20, 130), 180)
+        case .default:
+            return min(max(availableHeight * 0.42, 280), 380)
+        case .expanded:
+            return min(max(availableHeight * 0.72, 460), availableHeight - 32)
+        }
+    }
+
+    func nextState(for translation: CGFloat) -> ScriptPanelSnapState {
+        if translation < -80 {
+            switch self {
+            case .collapsed: return .default
+            case .default: return .expanded
+            case .expanded: return .expanded
+            }
+        }
+
+        if translation > 80 {
+            switch self {
+            case .expanded: return .default
+            case .default: return .collapsed
+            case .collapsed: return .collapsed
+            }
+        }
+
+        return self
+    }
+}
+
+private struct ScriptPanelView: View {
+    @Bindable var coordinator: SessionCoordinator
+    @Binding var panelState: ScriptPanelSnapState
+    @Binding var showNoteComposer: Bool
+    let onPanicTap: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Script")
+                        .font(.headline)
+                    Text(coordinator.mustCoverProgressText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button {
+                    showNoteComposer = true
+                } label: {
+                    Image(systemName: "plus")
+                        .frame(width: 36, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Add ad hoc note")
+
+                Button(action: onPanicTap) {
+                    Image(systemName: "rectangle.grid.1x2")
+                        .frame(width: 36, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Show all questions")
+            }
+            .padding(.top, 22)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    ForEach(QuestionPriority.allCases) { priority in
+                        let questions = coordinator.questions(for: priority)
+                        if !questions.isEmpty {
+                            VStack(alignment: .leading, spacing: 10) {
+                                Text(priority.title)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+
+                                ForEach(questions) { question in
+                                    ScriptQuestionRow(
+                                        question: question,
+                                        status: coordinator.status(for: question.id),
+                                        onTap: { coordinator.cycleStatus(for: question.id) },
+                                        onLongPress: { coordinator.skipQuestion(question.id) }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, 10)
+            }
+
+            HStack {
+                Button(panelState == .expanded ? "Collapse" : "Expand") {
+                    panelState = panelState == .expanded ? .default : .expanded
+                }
+                .font(.footnote.weight(.medium))
+
+                Spacer()
+
+                Text("\(coordinator.adHocNotes.count) note\(coordinator.adHocNotes.count == 1 ? "" : "s")")
+                    .font(.footnote.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 14)
+    }
+}
+
+private struct ScriptQuestionRow: View {
+    let question: GuideSnapshotQuestion
+    let status: QuestionCoverageStatus
+    let onTap: () -> Void
+    let onLongPress: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(question.text)
+                        .strikethrough(status == .skipped, color: .secondary)
+                        .foregroundStyle(status == .answered ? .secondary : .primary)
+                        .multilineTextAlignment(.leading)
+
+                    if !question.subPrompts.isEmpty {
+                        Text(question.subPrompts.joined(separator: " · "))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+
+                Spacer(minLength: 8)
+
+                StatusBadge(status: status)
+            }
+            .padding(12)
+            .background(statusBackground, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onLongPressGesture(perform: onLongPress)
+    }
+
+    private var statusBackground: Color {
+        switch status {
+        case .answered:
+            return Color.green.opacity(0.10)
+        case .partial:
+            return Color.yellow.opacity(0.14)
+        case .skipped:
+            return Color.secondary.opacity(0.10)
+        case .notStarted:
+            return Color.secondary.opacity(0.08)
+        }
+    }
+}
+
+private struct StatusBadge: View {
+    let status: QuestionCoverageStatus
+
+    var body: some View {
+        Text(status.title)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(badgeColor.opacity(0.18), in: Capsule())
+            .foregroundStyle(badgeColor)
+    }
+
+    private var badgeColor: Color {
+        switch status {
+        case .answered:
+            return .green
+        case .partial:
+            return .orange
+        case .skipped:
+            return .secondary
+        case .notStarted:
+            return .blue
+        }
+    }
+}
+
+private struct PanicQuestionListView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var coordinator: SessionCoordinator
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(QuestionPriority.allCases) { priority in
+                    let questions = coordinator.questions(for: priority)
+                    if !questions.isEmpty {
+                        Section(priority.title) {
+                            ForEach(questions) { question in
+                                HStack(alignment: .top, spacing: 12) {
+                                    Text(question.text)
+                                    Spacer(minLength: 8)
+                                    StatusBadge(status: coordinator.status(for: question.id))
+                                }
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    coordinator.cycleStatus(for: question.id)
+                                }
+                                .onLongPressGesture {
+                                    coordinator.skipQuestion(question.id)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("All Questions")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct UndoToast: View {
+    let text: String
+    let onUndo: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(text)
+                .font(.footnote)
+            Spacer(minLength: 12)
+            Button("Undo", action: onUndo)
+                .font(.footnote.weight(.semibold))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.regularMaterial, in: Capsule())
+        .padding(.horizontal, 24)
+    }
+}
+
+private struct QuickNoteOverlay: View {
+    @Binding var noteDraft: String
+    let onCancel: () -> Void
+    let onSave: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Quick note")
+                    .font(.headline)
+                Spacer()
+                Text(Date.now.formatted(date: .omitted, time: .shortened))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+
+            TextField("Capture a note without leaving the session", text: $noteDraft)
+                .textFieldStyle(.roundedBorder)
+
+            HStack {
+                Button("Cancel", action: onCancel)
+                Spacer()
+                Button("Save", action: onSave)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(noteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(16)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .shadow(color: Color.black.opacity(0.08), radius: 12, y: 4)
+    }
+}
+
+private struct LimitedModeBanner: View {
+    let message: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.callout)
+            Spacer(minLength: 0)
+        }
+        .padding()
+        .background(Color.orange.opacity(0.14), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+private extension QuestionCoverageStatus {
+    var nextTapStatus: QuestionCoverageStatus {
+        switch self {
+        case .notStarted:
+            return .partial
+        case .partial:
+            return .answered
+        case .answered, .skipped:
+            return .notStarted
+        }
+    }
+
+    var displayRank: Int {
+        switch self {
+        case .notStarted:
+            return 0
+        case .partial:
+            return 1
+        case .answered:
+            return 2
+        case .skipped:
+            return 3
+        }
+    }
+}

--- a/Packages/InterviewPartnerFeatures/Sources/InterviewPartnerFeatures/InterviewPartnerRootView.swift
+++ b/Packages/InterviewPartnerFeatures/Sources/InterviewPartnerFeatures/InterviewPartnerRootView.swift
@@ -2,10 +2,10 @@ import SwiftUI
 import InterviewPartnerServices
 
 public struct InterviewPartnerRootView: View {
-    private let appEnvironment: Sprint1AppEnvironment
+    private let appEnvironment: AppEnvironment
     @State private var workspaceRefreshToken = UUID()
 
-    public init(appEnvironment: Sprint1AppEnvironment) {
+    public init(appEnvironment: AppEnvironment) {
         self.appEnvironment = appEnvironment
     }
 
@@ -13,8 +13,11 @@ public struct InterviewPartnerRootView: View {
         TabView {
             NavigationStack {
                 SessionListView(
+                    guideRepository: appEnvironment.guideRepository,
                     sessionRepository: appEnvironment.sessionRepository,
                     workspaceExporter: appEnvironment.workspaceExporter,
+                    permissionManager: appEnvironment.permissionManager,
+                    makeTranscriptionService: appEnvironment.makeTranscriptionService,
                     workspaceRefreshToken: workspaceRefreshToken
                 )
             }

--- a/Packages/InterviewPartnerFeatures/Sources/InterviewPartnerFeatures/SessionListFeature.swift
+++ b/Packages/InterviewPartnerFeatures/Sources/InterviewPartnerFeatures/SessionListFeature.swift
@@ -1,27 +1,132 @@
 import Observation
 import SwiftUI
 import InterviewPartnerDomain
+import InterviewPartnerServices
+
+@MainActor
+@Observable
+final class SessionSetupCoordinator: Identifiable {
+    let id = UUID()
+
+    @ObservationIgnored
+    private let guideRepository: any GuideRepository
+    @ObservationIgnored
+    private let sessionRepository: any SessionRepository
+    @ObservationIgnored
+    private let permissionManager: any PermissionManager
+    @ObservationIgnored
+    private let makeTranscriptionService: @MainActor () -> any TranscriptionService
+
+    var guides: [GuideSummary] = []
+    var selectedGuideID: UUID?
+    var participantLabel = ""
+    var errorMessage: String?
+    var isStarting = false
+
+    init(
+        guideRepository: any GuideRepository,
+        sessionRepository: any SessionRepository,
+        permissionManager: any PermissionManager,
+        makeTranscriptionService: @escaping @MainActor () -> any TranscriptionService
+    ) {
+        self.guideRepository = guideRepository
+        self.sessionRepository = sessionRepository
+        self.permissionManager = permissionManager
+        self.makeTranscriptionService = makeTranscriptionService
+    }
+
+    func load() {
+        do {
+            guides = try guideRepository.fetchGuides()
+            selectedGuideID = selectedGuideID ?? guides.first?.id
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func startInterview() async -> SessionCoordinator? {
+        guard let selectedGuideID else {
+            errorMessage = "Choose a guide before starting the interview."
+            return nil
+        }
+
+        isStarting = true
+        defer { isStarting = false }
+
+        let permissionState: MicrophonePermissionState
+        switch permissionManager.microphonePermissionState() {
+        case .granted:
+            permissionState = .granted
+        case .notDetermined:
+            permissionState = await permissionManager.requestMicrophonePermission()
+        case .denied:
+            permissionState = .denied
+        }
+
+        guard permissionState == .granted else {
+            errorMessage = "Microphone access is required to run a live interview session."
+            return nil
+        }
+
+        do {
+            guard let guideDraft = try guideRepository.fetchGuide(id: selectedGuideID) else {
+                errorMessage = "That guide could not be loaded."
+                return nil
+            }
+
+            let session = try sessionRepository.createSession(
+                guideSnapshot: guideDraft.snapshot,
+                participantLabel: participantLabel.normalizedNilIfEmpty
+            )
+
+            errorMessage = nil
+            return SessionCoordinator(
+                session: session,
+                sessionRepository: sessionRepository,
+                transcriptionService: makeTranscriptionService()
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+            return nil
+        }
+    }
+}
 
 @MainActor
 @Observable
 final class SessionListCoordinator {
     @ObservationIgnored
+    private let guideRepository: any GuideRepository
+    @ObservationIgnored
     private let sessionRepository: any SessionRepository
     @ObservationIgnored
     fileprivate let workspaceExporter: any WorkspaceExporter
+    @ObservationIgnored
+    private let permissionManager: any PermissionManager
+    @ObservationIgnored
+    private let makeTranscriptionService: @MainActor () -> any TranscriptionService
 
     var sessions: [SessionSummary] = []
     var workspaceStatus: WorkspaceStatus
     var errorMessage: String?
     var showWorkspaceSetup = false
-    var showSprintTwoAlert = false
+    var showMissingGuideAlert = false
+    var sessionSetup: SessionSetupCoordinator?
+    var activeSession: SessionCoordinator?
 
     init(
+        guideRepository: any GuideRepository,
         sessionRepository: any SessionRepository,
-        workspaceExporter: any WorkspaceExporter
+        workspaceExporter: any WorkspaceExporter,
+        permissionManager: any PermissionManager,
+        makeTranscriptionService: @escaping @MainActor () -> any TranscriptionService
     ) {
+        self.guideRepository = guideRepository
         self.sessionRepository = sessionRepository
         self.workspaceExporter = workspaceExporter
+        self.permissionManager = permissionManager
+        self.makeTranscriptionService = makeTranscriptionService
         workspaceStatus = workspaceExporter.currentWorkspaceStatus()
     }
 
@@ -44,7 +149,25 @@ final class SessionListCoordinator {
             return
         }
 
-        showSprintTwoAlert = true
+        do {
+            let guides = try guideRepository.fetchGuides()
+            guard !guides.isEmpty else {
+                showMissingGuideAlert = true
+                return
+            }
+
+            let setup = SessionSetupCoordinator(
+                guideRepository: guideRepository,
+                sessionRepository: sessionRepository,
+                permissionManager: permissionManager,
+                makeTranscriptionService: makeTranscriptionService
+            )
+            setup.guides = guides
+            setup.selectedGuideID = guides.first?.id
+            sessionSetup = setup
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }
 
@@ -53,14 +176,20 @@ public struct SessionListView: View {
     private let workspaceRefreshToken: UUID
 
     public init(
+        guideRepository: any GuideRepository,
         sessionRepository: any SessionRepository,
         workspaceExporter: any WorkspaceExporter,
+        permissionManager: any PermissionManager,
+        makeTranscriptionService: @escaping @MainActor () -> any TranscriptionService,
         workspaceRefreshToken: UUID
     ) {
         _coordinator = State(
             initialValue: SessionListCoordinator(
+                guideRepository: guideRepository,
                 sessionRepository: sessionRepository,
-                workspaceExporter: workspaceExporter
+                workspaceExporter: workspaceExporter,
+                permissionManager: permissionManager,
+                makeTranscriptionService: makeTranscriptionService
             )
         )
         self.workspaceRefreshToken = workspaceRefreshToken
@@ -78,8 +207,8 @@ public struct SessionListView: View {
 
                     ContentUnavailableView(
                         "No Sessions Yet",
-                        systemImage: "mic.slash",
-                        description: Text("Sprint 1 establishes the session shell and workspace gate. Session setup and active interview flow land in Sprint 2.")
+                        systemImage: "waveform.path.ecg",
+                        description: Text("Pick a guide, add an optional participant label, and start a live interview session.")
                     )
 
                     Button("New Session") {
@@ -100,19 +229,7 @@ public struct SessionListView: View {
 
                     Section("Past Sessions") {
                         ForEach(coordinator.sessions) { session in
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text(session.participantLabel?.isEmpty == false ? session.participantLabel! : session.guideName)
-                                    .font(.headline)
-                                Text(session.guideName)
-                                    .foregroundStyle(.secondary)
-                                Text(session.startedAt.formatted(date: .abbreviated, time: .shortened))
-                                    .font(.footnote)
-                                    .foregroundStyle(.secondary)
-                                Text("Must Cover: \(session.answeredMustCoverCount)/\(session.mustCoverQuestionCount)")
-                                    .font(.footnote.monospacedDigit())
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding(.vertical, 4)
+                            SessionRowView(session: session)
                         }
                     }
                 }
@@ -140,10 +257,27 @@ public struct SessionListView: View {
                 }
             )
         }
-        .alert("Session Setup Arrives In Sprint 2", isPresented: $bindable.showSprintTwoAlert) {
+        .sheet(item: $bindable.sessionSetup) { setup in
+            SessionSetupSheet(
+                coordinator: setup,
+                onCancel: {
+                    coordinator.sessionSetup = nil
+                },
+                onStart: { activeSession in
+                    coordinator.activeSession = activeSession
+                    coordinator.sessionSetup = nil
+                }
+            )
+        }
+        .fullScreenCover(item: $bindable.activeSession, onDismiss: {
+            coordinator.load()
+        }) { activeSession in
+            ActiveSessionView(coordinator: activeSession)
+        }
+        .alert("Create A Guide First", isPresented: $bindable.showMissingGuideAlert) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Guide selection and the active interview sheet land in Sprint 2. Sprint 1 already enforces the workspace gate and local fallback behavior.")
+            Text("Sprint 2 sessions require a saved guide. Create one in the Guides tab before starting an interview.")
         }
         .alert(
             "Session List Error",
@@ -173,5 +307,131 @@ public struct SessionListView: View {
         }
         .padding()
         .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+private struct SessionSetupSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var coordinator: SessionSetupCoordinator
+    let onCancel: () -> Void
+    let onStart: (SessionCoordinator) -> Void
+
+    init(
+        coordinator: SessionSetupCoordinator,
+        onCancel: @escaping () -> Void,
+        onStart: @escaping (SessionCoordinator) -> Void
+    ) {
+        _coordinator = State(initialValue: coordinator)
+        self.onCancel = onCancel
+        self.onStart = onStart
+    }
+
+    var body: some View {
+        @Bindable var bindable = coordinator
+
+        NavigationStack {
+            Form {
+                Section("Guide") {
+                    Picker("Interview Guide", selection: $bindable.selectedGuideID) {
+                        ForEach(coordinator.guides) { guide in
+                            Text(guide.name).tag(Optional(guide.id))
+                        }
+                    }
+                    .pickerStyle(.navigationLink)
+                }
+
+                Section("Participant") {
+                    TextField("Optional participant label", text: $bindable.participantLabel)
+                        .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled()
+                }
+            }
+            .navigationTitle("New Session")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        onCancel()
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    if coordinator.isStarting {
+                        ProgressView()
+                    } else {
+                        Button("Start Interview") {
+                            Task {
+                                if let activeSession = await coordinator.startInterview() {
+                                    onStart(activeSession)
+                                    dismiss()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .task {
+                coordinator.load()
+            }
+            .alert(
+                "Session Setup Error",
+                isPresented: Binding(
+                    get: { coordinator.errorMessage != nil },
+                    set: { isPresented in
+                        if !isPresented {
+                            coordinator.errorMessage = nil
+                        }
+                    }
+                )
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(coordinator.errorMessage ?? "Unknown error")
+            }
+        }
+    }
+}
+
+private struct SessionRowView: View {
+    let session: SessionSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(session.participantLabel ?? session.guideName)
+                .font(.headline)
+            Text(session.guideName)
+                .foregroundStyle(.secondary)
+            Text(session.startedAt.formatted(date: .abbreviated, time: .shortened))
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Text("Must Cover: \(session.answeredMustCoverCount)/\(session.mustCoverQuestionCount)")
+                    .font(.footnote.monospacedDigit())
+                    .foregroundStyle(.secondary)
+
+                if let endedAt = session.endedAt {
+                    Spacer(minLength: 12)
+                    Text(Self.durationText(start: session.startedAt, end: endedAt))
+                        .font(.footnote.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private static func durationText(start: Date, end: Date) -> String {
+        let totalSeconds = max(Int(end.timeIntervalSince(start)), 0)
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%02dm %02ds", minutes, seconds)
+    }
+}
+
+private extension String {
+    var normalizedNilIfEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Packages/InterviewPartnerServices/Package.swift
+++ b/Packages/InterviewPartnerServices/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
     dependencies: [
         .package(path: "../InterviewPartnerDomain"),
         .package(path: "../InterviewPartnerData"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", revision: "9830ce835881c0d0d40f90aabfaae3a6da5bebfb"),
     ],
     targets: [
         .target(
@@ -24,6 +25,7 @@ let package = Package(
             dependencies: [
                 "InterviewPartnerDomain",
                 "InterviewPartnerData",
+                .product(name: "FluidAudio", package: "FluidAudio"),
             ]
         ),
     ]

--- a/Packages/InterviewPartnerServices/Sources/InterviewPartnerServices/AppEnvironment.swift
+++ b/Packages/InterviewPartnerServices/Sources/InterviewPartnerServices/AppEnvironment.swift
@@ -3,7 +3,7 @@ import InterviewPartnerData
 import InterviewPartnerDomain
 
 @MainActor
-public final class Sprint1AppEnvironment {
+public final class AppEnvironment {
     public let modelContainer: ModelContainer
     public let guideRepository: any GuideRepository
     public let sessionRepository: any SessionRepository
@@ -11,6 +11,7 @@ public final class Sprint1AppEnvironment {
     public let workspaceGuideImporter: any WorkspaceGuideImporter
     public let permissionManager: any PermissionManager
     public let keychainStore: any KeychainStore
+    public let makeTranscriptionService: @MainActor () -> any TranscriptionService
 
     public init(inMemoryOnly: Bool = false) throws {
         let modelContainer = try InterviewPartnerModelContainer.make(inMemoryOnly: inMemoryOnly)
@@ -19,8 +20,9 @@ public final class Sprint1AppEnvironment {
         self.modelContainer = modelContainer
         self.workspaceExporter = workspaceExporter
         workspaceGuideImporter = DefaultWorkspaceGuideImporter()
-        permissionManager = StubPermissionManager()
+        permissionManager = SystemPermissionManager()
         keychainStore = StubKeychainStore()
+        makeTranscriptionService = { DefaultTranscriptionService() }
         guideRepository = SwiftDataGuideRepository(
             modelContainer: modelContainer,
             workspaceExporter: workspaceExporter
@@ -28,3 +30,5 @@ public final class Sprint1AppEnvironment {
         sessionRepository = SwiftDataSessionRepository(modelContainer: modelContainer)
     }
 }
+
+public typealias Sprint1AppEnvironment = AppEnvironment

--- a/Packages/InterviewPartnerServices/Sources/InterviewPartnerServices/SupportServices.swift
+++ b/Packages/InterviewPartnerServices/Sources/InterviewPartnerServices/SupportServices.swift
@@ -1,3 +1,4 @@
+import AVFAudio
 import InterviewPartnerDomain
 
 @MainActor
@@ -10,11 +11,37 @@ public final class DefaultWorkspaceGuideImporter: WorkspaceGuideImporter {
 }
 
 @MainActor
-public final class StubPermissionManager: PermissionManager {
+public final class SystemPermissionManager: PermissionManager {
     public init() {}
 
     public func microphonePermissionState() -> MicrophonePermissionState {
-        .notDetermined
+        #if os(iOS)
+        switch AVAudioApplication.shared.recordPermission {
+        case .granted:
+            return .granted
+        case .denied:
+            return .denied
+        case .undetermined:
+            return .notDetermined
+        @unknown default:
+            return .notDetermined
+        }
+        #else
+        return .granted
+        #endif
+    }
+
+    public func requestMicrophonePermission() async -> MicrophonePermissionState {
+        #if os(iOS)
+        let granted = await withCheckedContinuation { continuation in
+            AVAudioApplication.requestRecordPermission { allowed in
+                continuation.resume(returning: allowed)
+            }
+        }
+        return granted ? .granted : .denied
+        #else
+        return .granted
+        #endif
     }
 }
 

--- a/Packages/InterviewPartnerServices/Sources/InterviewPartnerServices/TranscriptionServices.swift
+++ b/Packages/InterviewPartnerServices/Sources/InterviewPartnerServices/TranscriptionServices.swift
@@ -1,0 +1,847 @@
+import AVFoundation
+import FluidAudio
+import Foundation
+import InterviewPartnerDomain
+import OSLog
+import Speech
+
+public struct DiarizedSegment: Identifiable, Hashable, Sendable {
+    public let id: UUID
+    public let speakerIndex: Int
+    public let startTimeSeconds: TimeInterval
+    public let endTimeSeconds: TimeInterval
+    public let isFinal: Bool
+
+    public init(
+        id: UUID = UUID(),
+        speakerIndex: Int,
+        startTimeSeconds: TimeInterval,
+        endTimeSeconds: TimeInterval,
+        isFinal: Bool
+    ) {
+        self.id = id
+        self.speakerIndex = speakerIndex
+        self.startTimeSeconds = startTimeSeconds
+        self.endTimeSeconds = endTimeSeconds
+        self.isFinal = isFinal
+    }
+}
+
+public struct DiarizationSnapshot: Hashable, Sendable {
+    public let totalAudioSeconds: Double
+    public let segments: [DiarizedSegment]
+    public let attributedSpeakerCount: Int
+
+    public init(
+        totalAudioSeconds: Double,
+        segments: [DiarizedSegment],
+        attributedSpeakerCount: Int
+    ) {
+        self.totalAudioSeconds = totalAudioSeconds
+        self.segments = segments
+        self.attributedSpeakerCount = attributedSpeakerCount
+    }
+}
+
+public enum TranscriptionServiceEvent: Sendable {
+    case partialText(String)
+    case finalizedTurn(TranscriptTurn)
+    case transcriptGap(TranscriptGap)
+    case diarizationSnapshot(DiarizationSnapshot)
+    case limitedModeChanged(isLimited: Bool, message: String?)
+}
+
+public struct TranscriptionStopResult: Sendable {
+    public let reconciledTurns: [TranscriptTurn]
+    public let diarizationSnapshot: DiarizationSnapshot?
+    public let diarizationAvailable: Bool
+    public let limitedModeMessage: String?
+
+    public init(
+        reconciledTurns: [TranscriptTurn],
+        diarizationSnapshot: DiarizationSnapshot?,
+        diarizationAvailable: Bool,
+        limitedModeMessage: String?
+    ) {
+        self.reconciledTurns = reconciledTurns
+        self.diarizationSnapshot = diarizationSnapshot
+        self.diarizationAvailable = diarizationAvailable
+        self.limitedModeMessage = limitedModeMessage
+    }
+}
+
+@MainActor
+public protocol TranscriptionService: AnyObject {
+    func setEventHandler(_ handler: @escaping @Sendable (TranscriptionServiceEvent) -> Void)
+    func start(sessionID: UUID, startedAt: Date) async throws
+    func stop() async -> TranscriptionStopResult
+}
+
+public enum TranscriptionServiceError: LocalizedError {
+    case speechRecognizerUnavailable
+    case speechRecognizerRequiresServer
+
+    public var errorDescription: String? {
+        switch self {
+        case .speechRecognizerUnavailable:
+            "Speech recognition is unavailable on this device."
+        case .speechRecognizerRequiresServer:
+            "On-device speech recognition is unavailable on this device."
+        }
+    }
+}
+
+@MainActor
+public final class DefaultTranscriptionService: TranscriptionService {
+    private enum Constants {
+        static let eouDebounceMs = 640
+        static let gapThresholdSeconds = 10.0
+    }
+
+    private let logger = Logger(
+        subsystem: "com.mistercheese.InterviewPartner",
+        category: "DefaultTranscriptionService"
+    )
+    private let chunkSize: StreamingChunkSize
+    private let audioEngine = AVAudioEngine()
+    private let asrManager: StreamingEouAsrManager
+    private let diarizationEngine: LiveDiarizationEngine
+    private let speechFallback = SpeechFallbackTranscriptionEngine()
+
+    private var hasLoadedModels = false
+    private var callbacksConfigured = false
+    private var eventHandler: (@Sendable (TranscriptionServiceEvent) -> Void)?
+    private var sessionID: UUID?
+    private var startedAt: Date?
+    private var lastCommittedTranscript = ""
+    private var liveTurns: [TranscriptTurn] = []
+    private var liveGaps: [TranscriptGap] = []
+    private var lastTurnEndTimeSeconds: TimeInterval?
+    private var usingSpeechFallback = false
+    private var diarizationAvailable = true
+    private var limitedModeMessage: String?
+
+    public init(
+        chunkSize: StreamingChunkSize = .ms160,
+        diarizationConfig: SortformerConfig = .default
+    ) {
+        self.chunkSize = chunkSize
+        asrManager = StreamingEouAsrManager(
+            chunkSize: chunkSize,
+            eouDebounceMs: Constants.eouDebounceMs
+        )
+        diarizationEngine = LiveDiarizationEngine(config: diarizationConfig)
+    }
+
+    public func setEventHandler(_ handler: @escaping @Sendable (TranscriptionServiceEvent) -> Void) {
+        eventHandler = handler
+    }
+
+    public func start(sessionID: UUID, startedAt: Date) async throws {
+        self.sessionID = sessionID
+        self.startedAt = startedAt
+        lastCommittedTranscript = ""
+        liveTurns.removeAll()
+        liveGaps.removeAll()
+        lastTurnEndTimeSeconds = nil
+        usingSpeechFallback = false
+        diarizationAvailable = true
+        limitedModeMessage = nil
+
+        try await configureCallbacksIfNeeded()
+
+        do {
+            try await startFluidAudioSession()
+        } catch {
+            logger.error("FluidAudio start failed, falling back to Speech: \(error.localizedDescription, privacy: .public)")
+            try await startSpeechFallbackSession()
+        }
+    }
+
+    public func stop() async -> TranscriptionStopResult {
+        stopAudioEngine()
+
+        if usingSpeechFallback {
+            await speechFallback.stop()
+            let finalTurns = liveTurns.map { turn in
+                var reconciled = turn
+                reconciled.speakerLabel = "Speaker A"
+                reconciled.speakerLabelIsProvisional = false
+                return reconciled
+            }
+            return TranscriptionStopResult(
+                reconciledTurns: finalTurns,
+                diarizationSnapshot: nil,
+                diarizationAvailable: false,
+                limitedModeMessage: limitedModeMessage
+            )
+        }
+
+        do {
+            let transcript = try await asrManager.finish()
+            await appendIfNeeded(fromCumulativeTranscript: transcript)
+            await asrManager.reset()
+        } catch {
+            logger.error("Failed to finish ASR stream: \(error.localizedDescription, privacy: .public)")
+        }
+
+        let snapshot: DiarizationSnapshot?
+        let reconciledTurns: [TranscriptTurn]
+        if diarizationAvailable {
+            snapshot = await diarizationEngine.finalizeAndSnapshot()
+            reconciledTurns = reconcileTurns(snapshot: snapshot, turns: liveTurns)
+        } else {
+            snapshot = nil
+            reconciledTurns = liveTurns.map {
+                var turn = $0
+                turn.speakerLabel = "Speaker A"
+                turn.speakerLabelIsProvisional = false
+                turn.speakerMatchConfidence = nil
+                return turn
+            }
+        }
+
+        if let snapshot {
+            emit(.diarizationSnapshot(snapshot))
+        }
+
+        return TranscriptionStopResult(
+            reconciledTurns: reconciledTurns,
+            diarizationSnapshot: snapshot,
+            diarizationAvailable: diarizationAvailable,
+            limitedModeMessage: limitedModeMessage
+        )
+    }
+
+    private func startFluidAudioSession() async throws {
+        try await loadModelsIfNeeded()
+        await asrManager.reset()
+        await diarizationEngine.reset()
+
+        do {
+            try await diarizationEngine.prepareIfNeeded()
+            diarizationAvailable = true
+            limitedModeMessage = nil
+        } catch {
+            diarizationAvailable = false
+            limitedModeMessage = "Limited transcription mode: FluidAudio transcription is active, but live speaker diarization is unavailable."
+        }
+
+        emit(
+            .limitedModeChanged(
+                isLimited: !diarizationAvailable,
+                message: limitedModeMessage
+            )
+        )
+
+        try configureAudioSession()
+        try startAudioEngine(withDiarization: diarizationAvailable)
+    }
+
+    private func startSpeechFallbackSession() async throws {
+        usingSpeechFallback = true
+        diarizationAvailable = false
+        limitedModeMessage = "Limited transcription mode: using Speech fallback without speaker diarization."
+
+        emit(.limitedModeChanged(isLimited: true, message: limitedModeMessage))
+
+        try configureAudioSession()
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+
+        try await speechFallback.start(audioEngine: audioEngine, format: format) { [weak self] event in
+            Task { @MainActor [weak self] in
+                self?.handleSpeechFallbackEvent(event)
+            }
+        }
+    }
+
+    private func configureCallbacksIfNeeded() async throws {
+        guard !callbacksConfigured else { return }
+
+        await asrManager.setPartialCallback { [weak self] transcript in
+            Task { @MainActor [weak self] in
+                self?.handlePartialTranscript(transcript)
+            }
+        }
+
+        await asrManager.setEouCallback { [weak self] transcript in
+            Task { @MainActor [weak self] in
+                await self?.appendIfNeeded(fromCumulativeTranscript: transcript)
+            }
+        }
+
+        callbacksConfigured = true
+    }
+
+    private func loadModelsIfNeeded() async throws {
+        guard !hasLoadedModels else { return }
+
+        let modelDirectory = Self.defaultModelsDirectory(for: chunkSize)
+        try await Self.downloadModelsIfNeeded(to: modelDirectory, chunkSize: chunkSize)
+        try await asrManager.loadModels(modelDir: modelDirectory)
+        hasLoadedModels = true
+    }
+
+    private func configureAudioSession() throws {
+        #if os(iOS)
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .default, options: [.allowBluetoothHFP])
+        try session.setActive(true)
+        #endif
+    }
+
+    private func startAudioEngine(withDiarization: Bool) throws {
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        let asrManager = self.asrManager
+        let diarizationEngine = self.diarizationEngine
+
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(
+            onBus: 0,
+            bufferSize: 2048,
+            format: format,
+            block: AudioTapBridge.makeBlock(
+                asrManager: asrManager,
+                diarizationEngine: withDiarization ? diarizationEngine : nil
+            )
+        )
+
+        audioEngine.prepare()
+        try audioEngine.start()
+    }
+
+    private func stopAudioEngine() {
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+        #if os(iOS)
+        try? AVAudioSession.sharedInstance().setActive(false)
+        #endif
+    }
+
+    private func handlePartialTranscript(_ transcript: String) {
+        emit(.partialText(deltaText(fromCumulativeTranscript: transcript)))
+    }
+
+    private func appendIfNeeded(fromCumulativeTranscript transcript: String) async {
+        let newText = deltaText(fromCumulativeTranscript: transcript)
+        let trimmedText = newText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        lastCommittedTranscript = transcript
+        emit(.partialText(""))
+
+        guard
+            let sessionID,
+            let startedAt,
+            !trimmedText.isEmpty
+        else { return }
+
+        let attribution: DiarizationTurnAttribution
+        if diarizationAvailable {
+            attribution = await diarizationEngine.attributeNextTurn(
+                eouDebounceMs: Constants.eouDebounceMs
+            )
+        } else {
+            let now = Date.now
+            let elapsed = now.timeIntervalSince(startedAt)
+            attribution = DiarizationTurnAttribution(
+                speakerIndex: nil,
+                speakerLabel: "Speaker A",
+                estimatedStartTimeSeconds: lastTurnEndTimeSeconds ?? max(0, elapsed - 1),
+                estimatedEndTimeSeconds: elapsed,
+                confidence: 0,
+                note: "Fallback transcription does not provide diarization."
+            )
+        }
+
+        if let priorTurnEnd = lastTurnEndTimeSeconds,
+           attribution.estimatedStartTimeSeconds - priorTurnEnd >= Constants.gapThresholdSeconds {
+            let gap = TranscriptGap(
+                sessionID: sessionID,
+                startTimestamp: startedAt.addingTimeInterval(priorTurnEnd),
+                endTimestamp: startedAt.addingTimeInterval(attribution.estimatedStartTimeSeconds),
+                reason: .transcriptionUnavailable
+            )
+            liveGaps.append(gap)
+            emit(.transcriptGap(gap))
+        }
+
+        let turn = TranscriptTurn(
+            speakerLabel: attribution.speakerLabel,
+            text: trimmedText,
+            timestamp: startedAt.addingTimeInterval(attribution.estimatedEndTimeSeconds),
+            isFinal: true,
+            startTimeSeconds: attribution.estimatedStartTimeSeconds,
+            endTimeSeconds: attribution.estimatedEndTimeSeconds,
+            speakerMatchConfidence: diarizationAvailable ? attribution.confidence : nil,
+            speakerLabelIsProvisional: diarizationAvailable
+        )
+        liveTurns.append(turn)
+        lastTurnEndTimeSeconds = attribution.estimatedEndTimeSeconds
+
+        emit(.finalizedTurn(turn))
+        if diarizationAvailable {
+            emit(.diarizationSnapshot(await diarizationEngine.currentSnapshot()))
+        }
+    }
+
+    private func handleSpeechFallbackEvent(_ event: SpeechFallbackEvent) {
+        switch event {
+        case .partial(let text):
+            emit(.partialText(text))
+        case .final(let text):
+            Task {
+                await appendIfNeeded(fromCumulativeTranscript: text)
+            }
+        }
+    }
+
+    private func reconcileTurns(
+        snapshot: DiarizationSnapshot?,
+        turns: [TranscriptTurn]
+    ) -> [TranscriptTurn] {
+        guard let snapshot else {
+            return turns
+        }
+
+        var previousBoundary: TimeInterval = 0
+        return turns.map { turn in
+            let start = turn.startTimeSeconds ?? previousBoundary
+            let end = max(turn.endTimeSeconds ?? start, start)
+            let attribution = DominantSpeakerMatcher.attributeTurn(
+                segments: snapshot.segments.filter(\.isFinal),
+                windowStart: start,
+                windowEnd: end,
+                speakerLabel: defaultSpeakerLabel(for:)
+            )
+            previousBoundary = end
+
+            var reconciled = turn
+            reconciled.speakerLabel = attribution.speakerLabel
+            reconciled.speakerMatchConfidence = attribution.confidence
+            reconciled.speakerLabelIsProvisional = false
+            return reconciled
+        }
+    }
+
+    private func deltaText(fromCumulativeTranscript transcript: String) -> String {
+        guard transcript.hasPrefix(lastCommittedTranscript) else {
+            return transcript
+        }
+
+        return String(transcript.dropFirst(lastCommittedTranscript.count))
+    }
+
+    private func emit(_ event: TranscriptionServiceEvent) {
+        eventHandler?(event)
+    }
+
+    private static func defaultModelsDirectory(for chunkSize: StreamingChunkSize) -> URL {
+        let applicationSupportURL = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+
+        return applicationSupportURL
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            .appendingPathComponent("parakeet-eou-streaming", isDirectory: true)
+            .appendingPathComponent(chunkSize.modelSubdirectory, isDirectory: true)
+    }
+
+    private static func downloadModelsIfNeeded(
+        to destination: URL,
+        chunkSize: StreamingChunkSize
+    ) async throws {
+        let requiredModels = ModelNames.ParakeetEOU.requiredModels
+        let modelsExist = requiredModels.allSatisfy { modelName in
+            FileManager.default.fileExists(
+                atPath: destination.appendingPathComponent(modelName).path
+            )
+        }
+
+        guard !modelsExist else { return }
+
+        let modelsRoot = destination.deletingLastPathComponent().deletingLastPathComponent()
+        let repo: Repo
+
+        switch chunkSize {
+        case .ms160:
+            repo = .parakeetEou160
+        case .ms320, .ms1600:
+            repo = .parakeetEou320
+        }
+
+        try await DownloadUtils.downloadRepo(repo, to: modelsRoot)
+    }
+
+}
+
+private struct DiarizationTurnAttribution: Hashable, Sendable {
+    let speakerIndex: Int?
+    let speakerLabel: String
+    let estimatedStartTimeSeconds: TimeInterval
+    let estimatedEndTimeSeconds: TimeInterval
+    let confidence: Double
+    let note: String
+}
+
+private enum DominantSpeakerMatcher {
+    static func attributeNextTurn(
+        segments: [DiarizedSegment],
+        previousBoundarySeconds: TimeInterval,
+        audioDurationSeconds: TimeInterval,
+        eouDebounceMs: Int,
+        speakerLabel: (Int) -> String
+    ) -> DiarizationTurnAttribution {
+        let estimatedEnd = max(
+            previousBoundarySeconds,
+            audioDurationSeconds - (Double(eouDebounceMs) / 1000.0)
+        )
+        return attributeTurn(
+            segments: segments,
+            windowStart: previousBoundarySeconds,
+            windowEnd: estimatedEnd,
+            speakerLabel: speakerLabel
+        )
+    }
+
+    static func attributeTurn(
+        segments: [DiarizedSegment],
+        windowStart: TimeInterval,
+        windowEnd: TimeInterval,
+        speakerLabel: (Int) -> String
+    ) -> DiarizationTurnAttribution {
+        let sanitizedEnd = max(windowEnd, windowStart)
+        let windowDuration = max(sanitizedEnd - windowStart, 0.001)
+
+        var overlapBySpeaker: [Int: Double] = [:]
+        for segment in segments {
+            let overlap = max(
+                0,
+                min(segment.endTimeSeconds, sanitizedEnd) - max(segment.startTimeSeconds, windowStart)
+            )
+
+            guard overlap > 0 else { continue }
+            overlapBySpeaker[segment.speakerIndex, default: 0] += overlap
+        }
+
+        let rankedSpeakers = overlapBySpeaker.sorted { lhs, rhs in
+            if lhs.value == rhs.value {
+                return lhs.key < rhs.key
+            }
+            return lhs.value > rhs.value
+        }
+
+        guard let topSpeaker = rankedSpeakers.first else {
+            return DiarizationTurnAttribution(
+                speakerIndex: nil,
+                speakerLabel: "Unclear",
+                estimatedStartTimeSeconds: windowStart,
+                estimatedEndTimeSeconds: sanitizedEnd,
+                confidence: 0,
+                note: "No diarization segment overlapped the turn window."
+            )
+        }
+
+        let secondOverlap = rankedSpeakers.dropFirst().first?.value ?? 0
+        let dominantOverlap = topSpeaker.value
+        let confidence = min(1.0, dominantOverlap / windowDuration)
+
+        if dominantOverlap < 0.25 || (secondOverlap > 0 && dominantOverlap / secondOverlap < 1.25) {
+            return DiarizationTurnAttribution(
+                speakerIndex: nil,
+                speakerLabel: "Unclear",
+                estimatedStartTimeSeconds: windowStart,
+                estimatedEndTimeSeconds: sanitizedEnd,
+                confidence: confidence,
+                note: "Competing diarization segments overlap this turn window."
+            )
+        }
+
+        return DiarizationTurnAttribution(
+            speakerIndex: topSpeaker.key,
+            speakerLabel: speakerLabel(topSpeaker.key),
+            estimatedStartTimeSeconds: windowStart,
+            estimatedEndTimeSeconds: sanitizedEnd,
+            confidence: confidence,
+            note: "Mapped from dominant diarization overlap within the turn window."
+        )
+    }
+}
+
+private actor LiveDiarizationEngine {
+    private let audioConverter = AudioConverter()
+    private let diarizer: SortformerDiarizer
+
+    private var hasLoadedModels = false
+    private var totalSamples = 0
+    private var lastAssignedBoundarySeconds: TimeInterval = 0
+    private var speakerLabelsByIndex: [Int: String] = [:]
+
+    init(config: SortformerConfig = .default) {
+        diarizer = SortformerDiarizer(config: config, postProcessingConfig: .default)
+    }
+
+    func prepareIfNeeded() async throws {
+        guard !hasLoadedModels else { return }
+
+        let models = try await SortformerModels.loadFromHuggingFace(config: diarizer.config)
+        diarizer.initialize(models: models)
+        hasLoadedModels = true
+    }
+
+    func reset() {
+        diarizer.reset()
+        totalSamples = 0
+        lastAssignedBoundarySeconds = 0
+        speakerLabelsByIndex.removeAll()
+    }
+
+    func ingest(_ buffer: AVAudioPCMBuffer) throws {
+        let samples = try audioConverter.resampleBuffer(buffer)
+        totalSamples += samples.count
+        _ = try diarizer.processSamples(samples)
+    }
+
+    func finalizeAndSnapshot() -> DiarizationSnapshot {
+        diarizer.timeline.finalize()
+        return snapshot(includeTentative: false)
+    }
+
+    func currentSnapshot() -> DiarizationSnapshot {
+        snapshot(includeTentative: true)
+    }
+
+    func attributeNextTurn(eouDebounceMs: Int) -> DiarizationTurnAttribution {
+        let currentSnapshot = snapshot(includeTentative: true)
+        let attribution = DominantSpeakerMatcher.attributeNextTurn(
+            segments: currentSnapshot.segments,
+            previousBoundarySeconds: lastAssignedBoundarySeconds,
+            audioDurationSeconds: currentSnapshot.totalAudioSeconds,
+            eouDebounceMs: eouDebounceMs,
+            speakerLabel: speakerLabel(for:)
+        )
+
+        lastAssignedBoundarySeconds = attribution.estimatedEndTimeSeconds
+        return attribution
+    }
+
+    func speakerLabel(for speakerIndex: Int) -> String {
+        if let existingLabel = speakerLabelsByIndex[speakerIndex] {
+            return existingLabel
+        }
+
+        let label = defaultSpeakerLabel(for: speakerLabelsByIndex.count)
+
+        speakerLabelsByIndex[speakerIndex] = label
+        return label
+    }
+
+    private func snapshot(includeTentative: Bool) -> DiarizationSnapshot {
+        let finalizedSegments = diarizer.timeline.segments.enumerated().flatMap { speakerIndex, segments in
+            segments.map { segment in
+                DiarizedSegment(
+                    speakerIndex: speakerIndex,
+                    startTimeSeconds: TimeInterval(segment.startTime),
+                    endTimeSeconds: TimeInterval(segment.endTime),
+                    isFinal: true
+                )
+            }
+        }
+
+        let tentativeSegments: [DiarizedSegment]
+        if includeTentative {
+            tentativeSegments = diarizer.timeline.tentativeSegments.enumerated().flatMap { speakerIndex, segments in
+                segments.map { segment in
+                    DiarizedSegment(
+                        speakerIndex: speakerIndex,
+                        startTimeSeconds: TimeInterval(segment.startTime),
+                        endTimeSeconds: TimeInterval(segment.endTime),
+                        isFinal: false
+                    )
+                }
+            }
+        } else {
+            tentativeSegments = []
+        }
+
+        let allSegments = (finalizedSegments + tentativeSegments)
+            .sorted { lhs, rhs in
+                if lhs.startTimeSeconds == rhs.startTimeSeconds {
+                    return lhs.speakerIndex < rhs.speakerIndex
+                }
+                return lhs.startTimeSeconds < rhs.startTimeSeconds
+            }
+
+        return DiarizationSnapshot(
+            totalAudioSeconds: Double(totalSamples) / 16_000.0,
+            segments: allSegments,
+            attributedSpeakerCount: Set(allSegments.map(\.speakerIndex)).count
+        )
+    }
+}
+
+private enum SpeechFallbackEvent: Sendable {
+    case partial(String)
+    case final(String)
+}
+
+@MainActor
+private final class SpeechFallbackTranscriptionEngine {
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+    private var handler: (@Sendable (SpeechFallbackEvent) -> Void)?
+
+    func start(
+        audioEngine: AVAudioEngine,
+        format: AVAudioFormat,
+        handler: @escaping @Sendable (SpeechFallbackEvent) -> Void
+    ) async throws {
+        self.handler = handler
+
+        let authStatus = await Self.requestSpeechAuthorization()
+        guard authStatus == .authorized else {
+            throw TranscriptionServiceError.speechRecognizerUnavailable
+        }
+
+        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+            throw TranscriptionServiceError.speechRecognizerUnavailable
+        }
+        guard recognizer.supportsOnDeviceRecognition else {
+            throw TranscriptionServiceError.speechRecognizerRequiresServer
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.requiresOnDeviceRecognition = true
+        request.shouldReportPartialResults = true
+        self.request = request
+
+        let inputNode = audioEngine.inputNode
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self] buffer, _ in
+            self?.request?.append(buffer)
+        }
+
+        task = recognizer.recognitionTask(with: request) { [weak self] result, _ in
+            guard let self, let result else { return }
+            if result.isFinal {
+                self.handler?(.final(result.bestTranscription.formattedString))
+            } else {
+                self.handler?(.partial(result.bestTranscription.formattedString))
+            }
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+    }
+
+    func stop() async {
+        request?.endAudio()
+        task?.finish()
+        task?.cancel()
+        task = nil
+        request = nil
+        handler = nil
+    }
+
+    private static func requestSpeechAuthorization() async -> SFSpeechRecognizerAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+    }
+}
+
+private extension AVAudioPCMBuffer {
+    func deepCopy() -> AVAudioPCMBuffer? {
+        guard let copiedBuffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: frameLength
+        ) else {
+            return nil
+        }
+
+        copiedBuffer.frameLength = frameLength
+
+        let channelCount = Int(format.channelCount)
+        let frameLength = Int(self.frameLength)
+
+        if let source = floatChannelData, let destination = copiedBuffer.floatChannelData {
+            for channel in 0..<channelCount {
+                destination[channel].update(from: source[channel], count: frameLength)
+            }
+            return copiedBuffer
+        }
+
+        if let source = int16ChannelData, let destination = copiedBuffer.int16ChannelData {
+            for channel in 0..<channelCount {
+                destination[channel].update(from: source[channel], count: frameLength)
+            }
+            return copiedBuffer
+        }
+
+        if let source = int32ChannelData, let destination = copiedBuffer.int32ChannelData {
+            for channel in 0..<channelCount {
+                destination[channel].update(from: source[channel], count: frameLength)
+            }
+            return copiedBuffer
+        }
+
+        return nil
+    }
+}
+
+private enum AudioTapBridge {
+    private static let logger = Logger(
+        subsystem: "com.mistercheese.InterviewPartner",
+        category: "AudioTap"
+    )
+
+    nonisolated static func makeBlock(
+        asrManager: StreamingEouAsrManager,
+        diarizationEngine: LiveDiarizationEngine?
+    ) -> AVAudioNodeTapBlock {
+        { buffer, _ in
+            guard let bufferBox = buffer.deepCopy().map(SendablePCMBufferBox.init) else { return }
+
+            Task {
+                do {
+                    if let diarizationEngine {
+                        try await diarizationEngine.ingest(bufferBox.buffer)
+                    }
+                    _ = try await asrManager.process(audioBuffer: bufferBox.buffer)
+                } catch {
+                    logger.error(
+                        "Audio processing failed: \(error.localizedDescription, privacy: .public)"
+                    )
+                }
+            }
+        }
+    }
+}
+
+private final class SendablePCMBufferBox: @unchecked Sendable {
+    let buffer: AVAudioPCMBuffer
+
+    init(_ buffer: AVAudioPCMBuffer) {
+        self.buffer = buffer
+    }
+}
+
+private func defaultSpeakerLabel(for speakerIndex: Int) -> String {
+    switch speakerIndex {
+    case 0:
+        return "Speaker A"
+    case 1:
+        return "Speaker B"
+    case 2:
+        return "Speaker C"
+    case 3:
+        return "Speaker D"
+    default:
+        return "Speaker \(speakerIndex + 1)"
+    }
+}

--- a/rpi/plans/2026-03-17-15-52_interview-partner-impl-plan_enhanced.md
+++ b/rpi/plans/2026-03-17-15-52_interview-partner-impl-plan_enhanced.md
@@ -244,43 +244,49 @@ Sprint 0 proved the audio pipeline works. Now build the structure everything els
 > **⚠️ Longest sprint, highest risk.** Budget extra time. The FluidAudio ↔ SwiftUI wiring and the `ScriptPanelView` state interactions are the two hardest pieces in the entire v1 build.
 
 **Session setup sheet**
-- [ ] Sheet over `SessionListView`: guide picker (list of guides), optional participant label text field
-- [ ] "Start Interview" button → creates `Session` via `SessionRepository`, snapshots guide, presents `ActiveSessionView` as full-screen modal
+- [x] Sheet over `SessionListView`: guide picker (list of guides), optional participant label text field
+- [x] "Start Interview" button → creates `Session` via `SessionRepository`, snapshots guide, presents `ActiveSessionView` as full-screen modal
 
 **TranscriptionService** (in `InterviewPartnerServices`)
-- [ ] Move FluidAudio integration from Sprint 0 spike into `TranscriptionService` — this is the permanent home
-- [ ] `AVAudioEngine` + `AVAudioSession` setup (`.record`, `.allowBluetooth`)
-- [ ] `setPartialCallback` → publishes `partialText: String` to `SessionCoordinator`
-- [ ] `setEouCallback` → publishes finalized `TranscriptTurn` text plus inferred turn timing metadata; do **not** assume native speaker IDs exist on the ASR callback
-- [ ] Run a separate diarization path alongside streaming ASR (current spike direction: `SortformerDiarizer`) and expose provisional speaker labels plus the underlying speaker timeline to `SessionCoordinator`
-- [ ] Gap detection: if gap between EOU events exceeds threshold (e.g. 10s with no audio), emit `TranscriptGap` with start/end timestamps
-- [ ] `start()` / `stop()` methods
-- [ ] Fallback: if init fails, activate `SFSpeechRecognizer` (on-device), set `diarizationAvailable = false`
+- [x] Move FluidAudio integration from Sprint 0 spike into `TranscriptionService` — this is the permanent home
+- [x] `AVAudioEngine` + `AVAudioSession` setup (`.record`, `.allowBluetooth`)
+- [x] `setPartialCallback` → publishes `partialText: String` to `SessionCoordinator`
+- [x] `setEouCallback` → publishes finalized `TranscriptTurn` text plus inferred turn timing metadata; do **not** assume native speaker IDs exist on the ASR callback
+- [x] Run a separate diarization path alongside streaming ASR (current spike direction: `SortformerDiarizer`) and expose provisional speaker labels plus the underlying speaker timeline to `SessionCoordinator`
+- [x] Gap detection: if gap between EOU events exceeds threshold (e.g. 10s with no audio), emit `TranscriptGap` with start/end timestamps
+- [x] `start()` / `stop()` methods
+- [x] Fallback: if init fails, activate `SFSpeechRecognizer` (on-device), set `diarizationAvailable = false`
 
 **SessionCoordinator (`@MainActor @Observable`, in `InterviewPartnerFeatures`)**
-- [ ] Owns `TranscriptionService`, transcript array, gaps array, `partialTurn`, `questionStatuses`, `adHocNotes`, `elapsedSeconds`
-- [ ] **Incremental persistence:** each `TranscriptTurn`, `TranscriptGap`, `QuestionStatus` change, and `AdHocNote` written immediately via `SessionRepository` — not batched at session end
-- [ ] `Timer.publish` for elapsed time (pauses on app background)
-- [ ] Persist live speaker labels as **provisional** during the active session; ambiguous turns remain `Unclear` instead of forcing a confident label
+- [x] Owns `TranscriptionService`, transcript array, gaps array, `partialTurn`, `questionStatuses`, `adHocNotes`, `elapsedSeconds`
+- [x] **Incremental persistence:** each `TranscriptTurn`, `TranscriptGap`, `QuestionStatus` change, and `AdHocNote` written immediately via `SessionRepository` — not batched at session end
+- [x] `Timer.publish` for elapsed time (pauses on app background)
+- [x] Persist live speaker labels as **provisional** during the active session; ambiguous turns remain `Unclear` instead of forcing a confident label
 - [ ] `endSession()`: stops transcription, finalizes the full diarization timeline, runs a post-pass reconciliation over transcript turns before export/persistence becomes durable, finalizes `Session` via `SessionRepository`, creates `ExportQueueEntry`, triggers immediate export attempt
 
+> **Sprint 2 scope note (March 18, 2026):** `endSession()` now stops transcription, reconciles speaker labels, and finalizes the `Session` locally. Per user clarification, `ExportQueueEntry` creation and immediate export attempts remain deferred to Sprint 3.
+
 **ActiveSessionView layout**
-- [ ] `SessionHeaderView`: participant label, elapsed timer, "End" button with confirmation dialog
-- [ ] `TranscriptView`: scrolling list of `TranscriptTurn`s and `TranscriptGap` markers, auto-scrolls to latest, Speaker A left-aligned / Speaker B right-aligned, color-coded, partial turn shown in-progress at bottom; gap markers rendered as `[transcription unavailable HH:MM–HH:MM]` in muted style
-- [ ] Live speaker chips/labels visually communicate that in-session attribution is provisional (for example, subdued styling, confidence hint, or explicit "live" treatment)
-- [ ] "Limited transcription mode" banner if `diarizationAvailable = false`
+- [x] `SessionHeaderView`: participant label, elapsed timer, "End" button with confirmation dialog
+- [x] `TranscriptView`: scrolling list of `TranscriptTurn`s and `TranscriptGap` markers, auto-scrolls to latest, Speaker A left-aligned / Speaker B right-aligned, color-coded, partial turn shown in-progress at bottom; gap markers rendered as `[transcription unavailable HH:MM–HH:MM]` in muted style
+- [x] Live speaker chips/labels visually communicate that in-session attribution is provisional (for example, subdued styling, confidence hint, or explicit "live" treatment)
+- [x] "Limited transcription mode" banner if `diarizationAvailable = false`
 
 > **Sprint 2 diarization direction:** Keep live labels because they materially improve in-session readability, but treat them as provisional. The durable session record should come from a post-session reconciliation pass over the completed diarization timeline, not from the first live overlap guess alone.
 
 **ScriptPanelView (bottom sheet)**
-- [ ] Collapsible bottom sheet with three snap states: collapsed / default / expanded
+- [x] Collapsible bottom sheet with three snap states: collapsed / default / expanded
 - [ ] Header shows "3 of 4 Must Cover · Xm left"
-- [ ] Questions grouped by priority (Must Cover → Should Cover → Nice to Have), each with status badge
-- [ ] Tap cycles: Not Started → Partial → Answered; each tap persists immediately via `SessionRepository`
-- [ ] Long-press marks Skipped, with undo toast (3 seconds)
-- [ ] Answered questions dim and float to bottom of group; Skipped show muted strikethrough
-- [ ] Ad hoc note button (`+`): one-line overlay with timestamp, saves `AdHocNote` via `SessionRepository` without navigating away
-- [ ] Panic button (`⊞`): full-screen question list with all status badges
+- [x] Questions grouped by priority (Must Cover → Should Cover → Nice to Have), each with status badge
+- [x] Tap cycles: Not Started → Partial → Answered; each tap persists immediately via `SessionRepository`
+- [x] Long-press marks Skipped, with undo toast (3 seconds)
+- [x] Answered questions dim and float to bottom of group; Skipped show muted strikethrough
+- [x] Ad hoc note button (`+`): one-line overlay with timestamp, saves `AdHocNote` via `SessionRepository` without navigating away
+- [x] Panic button (`⊞`): full-screen question list with all status badges
+
+> **Sprint 2 UX note (March 18, 2026):** The script header currently shows Must Cover progress plus elapsed time (`Xm elapsed`). Countdown / `Xm left` remains tied to the later target-duration work.
+
+> **Verification note (March 18, 2026):** `xcodebuildmcp simulator build --workspace-path /Users/mistercheese/.codex/worktrees/00ae/interview-partner/InterviewPartner.xcworkspace --scheme InterviewPartner --simulator-name "iPhone 15" --derived-data-path /Users/mistercheese/.codex/worktrees/00ae/interview-partner/.build/xcodebuildmcp-derived` and `xcodebuildmcp simulator build-and-run --workspace-path /Users/mistercheese/.codex/worktrees/00ae/interview-partner/InterviewPartner.xcworkspace --scheme InterviewPartner --simulator-name "iPhone 15" --derived-data-path /Users/mistercheese/.codex/worktrees/00ae/interview-partner/.build/xcodebuildmcp-derived` both succeeded. Manual simulator validation on March 18, 2026 confirmed the session setup sheet presents with a saved guide, the active session screen launches, question status taps update, and the quick-note overlay appears in-session after microphone permission was granted.
 
 > **Exit criterion:** Start a session with a guide. Speak for 5 minutes. Manually mark 2 questions Answered, 1 Partial, 1 Skipped. Add one ad hoc note. End the session. Find it in session history. Live labels can still be wrong during capture, but the session must complete with readable provisional attribution and a post-stop reconciliation pass.
 


### PR DESCRIPTION
## Summary
- implement the Sprint 2 active session flow with real session setup, active-session UI, incremental persistence, and question/note interactions
- add live transcription plumbing with FluidAudio, Speech fallback, diarization metadata, and session finalization
- update the implementation plan checkboxes and add repository tests plus simulator smoke-test validation

## Verification
- xcodebuildmcp simulator build-and-run --workspace-path /Users/mistercheese/.codex/worktrees/00ae/interview-partner/InterviewPartner.xcworkspace --scheme InterviewPartner --simulator-id 2E2657CB-3687-4490-8FE5-6A5ABA183190 --derived-data-path /Users/mistercheese/.codex/worktrees/00ae/interview-partner/.build/xcodebuildmcp-derived
- xcodebuildmcp swift-package test --package-path /Users/mistercheese/.codex/worktrees/00ae/interview-partner/Packages/InterviewPartnerData
- swift test (in /Users/mistercheese/.codex/worktrees/00ae/interview-partner/Packages/InterviewPartnerDomain)
- manual simulator smoke test covering create session, live partial transcript, finalized persisted turn, and end session history return